### PR TITLE
fix readme

### DIFF
--- a/readme.en.md
+++ b/readme.en.md
@@ -193,7 +193,9 @@ go build -o gochat.bin -tags=etcd main.go
 ./gochat.bin -module logic
 
 2,Start the connect layer
-./gochat.bin -module connect
+./gochat.bin -module connect_tcp
+or  
+./gochat.bin -module connect_websocket
 
 3,Start the task layer
 ./gochat.bin -module task

--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,9 @@ go build -o gochat.bin -tags=etcd main.go
 ./gochat.bin -module logic
 
 2,启动connect层
-./gochat.bin -module connect
+./gochat.bin -module connect_tcp
+或者  
+./gochat.bin -module connect_websocket
 
 3,启动task层
 ./gochat.bin -module task


### PR DESCRIPTION
按照文档里的[安装步骤](https://github.com/LockGit/gochat#%E5%AE%89%E8%A3%85)，执行`./gochat.bin -module connect` 会报错
```sh
start run connect module
exiting,module param error!
```
在`mian.go`代码里会走到 default 分支，因为没有 `connect` 分支，只有 `connect_tcp` 或者 `connect_websocket`  分支。

因此正确启动`connect`  模块的方式是 ` connect_tcp` 或者 `connect_websocket`，在我的笔记本上执行结果如下

```sh
~/go/src/github.com/LockGit/gochat(master*) » ./gochat.bin --module connect_tcp                                                                                                                                                                
start run connect_tcp module
INFO[0000] Connect start run at-->tcp:0.0.0.0:6914      
INFO[0000] Connect start run at-->tcp:0.0.0.0:6915      
INFO[0000] start tcp listen at:0.0.0.0:7001             
INFO[0000] start tcp listen at:0.0.0.0:7002             
run connect_tcp module done!
2020/12/13 02:20:57 server.go:174: INFO : server pid:12150
2020/12/13 02:20:57 server.go:174: INFO : server pid:12150

~/go/src/github.com/LockGit/gochat(master*) » ./gochat.bin --module connect_websocket                                                                                                                                                          
start run connect_websocket module
INFO[0000] Connect start run at-->tcp:0.0.0.0:6912      
INFO[0000] Connect start run at-->tcp:0.0.0.0:6913      
2020/12/13 02:35:01 server.go:174: INFO : server pid:14327
2020/12/13 02:35:01 server.go:174: INFO : server pid:14327
```





