### PR TITLE
fix coredump

### DIFF
--- a/connect/server.go
+++ b/connect/server.go
@@ -129,7 +129,7 @@ func (s *Server) readPump(ch *Channel, c *Connect) {
 		if err := json.Unmarshal([]byte(message), &connReq); err != nil {
 			logrus.Errorf("message struct %+v", connReq)
 		}
-		if connReq.AuthToken == "" {
+		if connReq == nil || connReq.AuthToken == "" {
 			logrus.Errorf("s.operator.Connect no authToken")
 			return
 		}


### PR DESCRIPTION
使用websocket客户端（见websocket_client.txt）连接并发送msg，会导致coredump（如图）。
![image](https://user-images.githubusercontent.com/89025318/200158896-023e86ba-6f05-42ce-a8f3-6ffcd5f53cb7.png)

[websocket_client.txt](https://github.com/LockGit/gochat/files/9945313/websocket_client.txt)
